### PR TITLE
[ Home/20 ] 홈 화면 합치기 얍

### DIFF
--- a/src/components/Home/AdBanner.tsx
+++ b/src/components/Home/AdBanner.tsx
@@ -58,6 +58,7 @@ const St = {
 
     width: fit-content;
     margin: auto;
+    padding-bottom: 5.8rem;
   `,
   Swiper: styled(Swiper)`
     width: 121.6rem;
@@ -76,9 +77,9 @@ const St = {
     justify-content: space-between;
 
     position: absolute;
-    top: 50%;
-    left: -3rem;
-    transform: translate(0, -50%);
+    top: 50.5%;
+    left: -2.9rem;
+    transform: translate(-0.2%, -95%);
 
     width: 128rem;
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,8 @@
-
-import AdBanner from '../components/Home/AdBanner';
 import { useNavigate } from 'react-router';
 import { styled } from 'styled-components';
+
 import { IcCleanService, IcNew } from '../assets/icon';
+import AdBanner from '../components/Home/AdBanner';
 import MenuBox from '../components/Home/MenuBox';
 import { HOME_CLEANING_MENU, HOME_MAIN_MENU } from '../constants/homMenuContents';
 
@@ -50,6 +50,7 @@ const HomePage = () => {
           </St.Bottomcontent>
         </St.BottomSection>
       </St.MenuWrapper>
+      <AdBanner />
     </St.HomeWrapper>
   );
 };


### PR DESCRIPTION
## 🔥 Related Issues

resolved #20 

## 💜 작업 내용
- [x]  홈 하단에 배너 추가 후 홈 화면 완성
- [x]  합치면서 생긴 배너 css 무너짐 해결

## ✅ PR Point
- 메뉴박스만 있던 홈 화면에 배너를 합쳤어요
- 합치는 과정에서 padding 값을 주면서 position absolute로 넣어준 배너 css가 무너져 고쳤습니당

## 😡 Trouble Shooting
배너 css 무너짐 해결 -> 노가다 ..!

## 👀 스크린샷 / GIF / 링크
<img width="1440" alt="image" src="https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/77691829/ad2c9050-42c3-4c0c-9c19-96017253f00a">
노가다로 이것저것 줄여가며 . . . 피그마 치수랑 맞추기 성공! 휴우

<br/>

https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/77691829/9e7d1ef4-b6b0-49b1-8968-5410c6b8ee44

원래 있던 기능들도 잘 돌아가는거 확인했습니당


