### PR TITLE
[ Common/24 ] 메인레이아웃 완성

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -90,12 +90,10 @@ const St = {
     display: flex;
     justify-content: center;
 
-    position: fixed;
-    bottom: 0;
-
     width: 100%;
     height: 32.2rem;
     padding: 3.9rem 10rem 4.3rem 10rem;
+    margin-top: auto;
 
     background-color: ${({ theme }) => theme.colors.Grey100};
     & * {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -72,20 +72,17 @@ const Header = () => {
 export default Header;
 
 const St = {
-  // header 포지션은 나중에 mainLayout 만들 때 적용시킬게용!
   HeaderWrapper: styled.header`
-    /* position: fixed;
+    position: fixed;
     top: 0;
-    left: 0;
-    right: 0; */
+
+    width: 100%;
   `,
   //gnb 부분
   GnbWrapper: styled.section`
     display: flex;
     align-items: center;
 
-    //1440px 100% 기준 양 옆 padding 7rem
-    width: 100%;
     height: 8.6rem;
     padding: 2.3rem 10rem 2rem 10rem;
 
@@ -192,6 +189,8 @@ const St = {
     width: 100%;
     height: 5.4rem;
     padding: 1.6rem 10rem;
+
+    background-color: ${({ theme }) => theme.colors.White};
   `,
   LnbContainer: styled.ul`
     display: flex;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,3 +1,5 @@
+import { styled } from 'styled-components';
+
 import MenuBox from '../components/Home/MenuBox';
 
 const HomePage = () => {
@@ -5,8 +7,20 @@ const HomePage = () => {
     <>
       홈 페이지입니다!
       <MenuBox />
+      <Test>테스트용 호마ㅕㄴ !~~~</Test>
+      <Test2>테스트용 호마ㅕㄴ !~~~</Test2>
     </>
   );
 };
 
 export default HomePage;
+
+const Test = styled.div`
+  background-color: pink;
+  height: 100vh;
+`;
+
+const Test2 = styled.div`
+  background-color: yellow;
+  height: 100vh;
+`;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,3 @@
-import { styled } from 'styled-components';
-
 import MenuBox from '../components/Home/MenuBox';
 
 const HomePage = () => {
@@ -7,20 +5,8 @@ const HomePage = () => {
     <>
       홈 페이지입니다!
       <MenuBox />
-      <Test>테스트용 호마ㅕㄴ !~~~</Test>
-      <Test2>테스트용 호마ㅕㄴ !~~~</Test2>
     </>
   );
 };
 
 export default HomePage;
-
-const Test = styled.div`
-  background-color: pink;
-  height: 100vh;
-`;
-
-const Test2 = styled.div`
-  background-color: yellow;
-  height: 100vh;
-`;

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -6,26 +6,26 @@ import Header from '../components/common/Header';
 
 const MainLayout = () => {
   return (
-    <St.mainLayoutWrapper>
+    <St.MainLayoutWrapper>
       <Header />
-      <St.mainWrapper>
+      <St.MainWrapper>
         <Outlet />
-      </St.mainWrapper>
+      </St.MainWrapper>
       <Footer />
-    </St.mainLayoutWrapper>
+    </St.MainLayoutWrapper>
   );
 };
 
 export default MainLayout;
 
 const St = {
-  mainLayoutWrapper: styled.div`
+  MainLayoutWrapper: styled.div`
     display: flex;
     flex-direction: column;
     min-height: 100vh;
   `,
   //fixe된 header 높이 만큼 컨텐츠 영역의 위쪽 padding 값 주기
-  mainWrapper: styled.main`
+  MainWrapper: styled.main`
     padding-top: 14rem;
   `,
 };

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -8,7 +8,9 @@ const MainLayout = () => {
   return (
     <St.mainLayoutWrapper>
       <Header />
-      <Outlet />
+      <St.mainWrapper>
+        <Outlet />
+      </St.mainWrapper>
       <Footer />
     </St.mainLayoutWrapper>
   );
@@ -21,5 +23,9 @@ const St = {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+  `,
+  //fixe된 header 높이 만큼 컨텐츠 영역의 위쪽 padding 값 주기
+  mainWrapper: styled.main`
+    padding-top: 14rem;
   `,
 };

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -1,16 +1,25 @@
 import { Outlet } from 'react-router-dom';
+import { styled } from 'styled-components';
 
 import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
 
 const MainLayout = () => {
   return (
-    <>
+    <St.mainLayoutWrapper>
       <Header />
       <Outlet />
       <Footer />
-    </>
+    </St.mainLayoutWrapper>
   );
 };
 
 export default MainLayout;
+
+const St = {
+  mainLayoutWrapper: styled.div`
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  `,
+};


### PR DESCRIPTION
## 🔥 Related Issues

resolved #24 

## 💜 작업 내용

- [x] 헤더와 푸터를 합쳐 메인레이아웃 완성

## ✅ PR Point

- 헤더 & 푸터 위치 조정 : 헤더 -> 상단 고정 / 푸터 -> 최하단
- fixed된 헤더 높이만큼 컨텐츠 영역 위쪽 패딩 값을 줘 겹치지 않도록 함

## 😡 Trouble Shooting
x

## 👀 스크린샷 / GIF / 링크

https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/77691829/a0a657d8-8f4b-4401-81f6-e123df8dfffa

