### PR TITLE
[ List/19 ] 매물 목록 페이지에서 필요한 API type 세팅 

### DIFF
--- a/src/components/List/ProductBox.tsx
+++ b/src/components/List/ProductBox.tsx
@@ -3,7 +3,12 @@ import styled from "styled-components";
 import { IcStar } from "../../assets/icon";
 import { ImgRoom1 } from "../../assets/image";
 
-const ProductBox = () => {
+interface ProductBoxContent {
+  
+}
+
+const ProductBox = (props : ProductBoxContent) => {
+  
   return (
   <St.ProductBoxWrapper>
     <ImgRoom1/>

--- a/src/components/List/ProductBox.tsx
+++ b/src/components/List/ProductBox.tsx
@@ -3,11 +3,7 @@ import styled from "styled-components";
 import { IcStar } from "../../assets/icon";
 import { ImgRoom1 } from "../../assets/image";
 
-interface ProductBoxContent {
-  
-}
-
-const ProductBox = (props : ProductBoxContent) => {
+const ProductBox = () => {
   
   return (
   <St.ProductBoxWrapper>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -32,6 +32,7 @@ const ListPage = () => {
 
 export default ListPage;
 
+
 const St = {
   ListWrapper : styled.section`
     display: flex;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,3 +1,10 @@
+export interface productRequest {
+  flag: string;
+  order: string;
+  page: number;
+  size: number;
+}
+
 export interface productResponse {
   id: number;
   grade: number;

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -1,13 +1,9 @@
-export interface productInfo {
-  id: string;
-  title: string;
-  createAt: Date;
-  image: string;
-  description: string;
-  tags: {
-    state: string;
-    price: string;
-    size: number;
-  };
+export interface productResponse {
+  id: number;
   grade: number;
+  good: number;
+  average: number;
+  bad: number;
+  title: string;
+  image: string;
 }


### PR DESCRIPTION
## 🔥 Related Issues

resolved #19 

## 💜 작업 내용
- [x] API 명세서 확인
- [x] request params type 세팅
- [x] response data type 세팅  

## ✅ PR Point
- 매물목록 조회에 필요한 reponse, request 데이터 타입을 `product.ts` 내부에 세팅해줬습니다. 
- 같은 페이지에서 제가 맡은 또다른 API인 매물 삭제는 별도로 request, response type을 세팅해줄 필요가 없어서 안썼어요! 


## 👀 스크린샷 / GIF / 링크

<img width="684" alt="스크린샷 2023-05-22 오후 8 44 13" src="https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/81505421/035a7d6d-8998-467e-bbd5-681d02059cb5">

<img width="427" alt="스크린샷 2023-05-22 오후 8 43 41" src="https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/81505421/8453ea06-cd30-4da7-90e8-23e4cc31b256">


