### PR TITLE
[ List modal/44 ] 삭제 재확인 모달 UI 구현

### DIFF
--- a/src/components/List/DeleteModal.tsx
+++ b/src/components/List/DeleteModal.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import styled from "styled-components";
+
+export interface ModalProps {
+    isDeleteShowing : boolean;
+    handleRevoke : React.MouseEventHandler;
+    handleConfirm : React.MouseEventHandler;
+}
+
+const DeleteModal = ({ isDeleteShowing, handleRevoke, handleConfirm }: ModalProps) => {
+  return (
+    <>
+    {isDeleteShowing && (
+        <St.DeleteModalWrapper>
+            <St.DeleteModal>
+                <St.Text>
+                작성하신 내역을 삭제하시겠습니까?<br/>삭제 후에는 복구할 수 없습니다.
+                </St.Text>
+                <St.Buttons>
+                    <St.RevokeBtn type="button" onClick={handleRevoke}>취소</St.RevokeBtn>
+                    <St.ConfirmBtn type="button" onClick={handleConfirm}>확인</St.ConfirmBtn>
+                </St.Buttons>
+            </St.DeleteModal>
+        </St.DeleteModalWrapper>
+    )}
+    </>
+  )
+}
+
+export default DeleteModal
+
+const St = {
+    DeleteModalWrapper : styled.section`
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        position: fixed;
+        top: 0;
+        left: 0;
+
+        width: 100%;
+        height: 100%;
+
+        background-color: rgba(47, 52, 56, 0.4);
+
+        z-index: 1;
+    `,
+    DeleteModal : styled.article`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+
+        position: relative;
+
+        width: 42.8rem;
+        padding: 2.3rem 2rem;
+        
+        border-radius: 0.9rem;
+        background-color: ${({ theme }) => theme.colors.White};
+        
+    `,
+    Text : styled.p`
+        ${({ theme }) => theme.fonts.Body6};
+
+        text-align: center;
+    `,
+    Buttons : styled.div`
+        display: flex;
+        gap:0.8rem;
+
+        width: 100%;
+        margin-top: 1.8rem;
+
+        & > button {
+            width: 100%;
+            height: 4.8rem;
+
+            border-radius: 0.4rem;
+        }
+        
+    `,
+    RevokeBtn : styled.button`
+        border: 0.1rem solid ${({ theme }) => theme.colors.Grey300};;
+        background-color: ${({ theme }) => theme.colors.White};
+    `,
+    ConfirmBtn : styled.button`
+        background-color: ${({ theme }) => theme.colors.Blue};
+        color: ${({ theme }) => theme.colors.White};
+    `
+
+}

--- a/src/components/List/DeleteModal.tsx
+++ b/src/components/List/DeleteModal.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import styled from "styled-components";
 
-export interface ModalProps {
+export interface DeleteModalProps {
     isDeleteShowing : boolean;
     handleToggle : React.MouseEventHandler;
 }
 
-const DeleteModal = ({ isDeleteShowing, handleToggle }: ModalProps) => {
+const DeleteModal = ({ isDeleteShowing, handleToggle }: DeleteModalProps) => {
   return (
     <>
     {isDeleteShowing && (

--- a/src/components/List/DeleteModal.tsx
+++ b/src/components/List/DeleteModal.tsx
@@ -3,11 +3,10 @@ import styled from "styled-components";
 
 export interface ModalProps {
     isDeleteShowing : boolean;
-    handleRevoke : React.MouseEventHandler;
-    handleConfirm : React.MouseEventHandler;
+    handleToggle : React.MouseEventHandler;
 }
 
-const DeleteModal = ({ isDeleteShowing, handleRevoke, handleConfirm }: ModalProps) => {
+const DeleteModal = ({ isDeleteShowing, handleToggle }: ModalProps) => {
   return (
     <>
     {isDeleteShowing && (
@@ -17,8 +16,8 @@ const DeleteModal = ({ isDeleteShowing, handleRevoke, handleConfirm }: ModalProp
                 작성하신 내역을 삭제하시겠습니까?<br/>삭제 후에는 복구할 수 없습니다.
                 </St.Text>
                 <St.Buttons>
-                    <St.RevokeBtn type="button" onClick={handleRevoke}>취소</St.RevokeBtn>
-                    <St.ConfirmBtn type="button" onClick={handleConfirm}>확인</St.ConfirmBtn>
+                    <St.RevokeBtn type="button" onClick={handleToggle}>취소</St.RevokeBtn>
+                    <St.ConfirmBtn type="button" onClick={handleToggle}>확인</St.ConfirmBtn>
                 </St.Buttons>
             </St.DeleteModal>
         </St.DeleteModalWrapper>

--- a/src/components/List/MoreModal.tsx
+++ b/src/components/List/MoreModal.tsx
@@ -20,7 +20,10 @@ const MoreModal = ({ isShowing, handleClose, handleDelete }: ModalProps) => {
                 <St.Header>더보기</St.Header>
                 <St.CloseBtn onClick={handleClose}><IcBack/></St.CloseBtn>
                 <St.ModalBtn type="button">수정하기</St.ModalBtn>
-                <St.ModalBtn type="button" onClick={handleDelete}>삭제하기</St.ModalBtn>
+                <St.ModalBtn type="button" 
+                    onClick={()=>{handleDelete(); handleClose();}}>
+                    삭제하기
+                </St.ModalBtn>
             </St.ListModal>
         </St.ListModalWrapper>
     )}

--- a/src/components/List/MoreModal.tsx
+++ b/src/components/List/MoreModal.tsx
@@ -6,9 +6,10 @@ import { IcBack } from "../../assets/icon";
 export interface ModalProps {
     isShowing : boolean;
     handleClose : React.MouseEventHandler;
+    handleDelete : React.MouseEventHandler;
 }
 
-const MoreModal = ({ isShowing, handleClose }: ModalProps) => {
+const MoreModal = ({ isShowing, handleClose, handleDelete }: ModalProps) => {
     
 
   return (
@@ -19,7 +20,7 @@ const MoreModal = ({ isShowing, handleClose }: ModalProps) => {
                 <St.Header>더보기</St.Header>
                 <St.CloseBtn onClick={handleClose}><IcBack/></St.CloseBtn>
                 <St.ModalBtn type="button">수정하기</St.ModalBtn>
-                <St.ModalBtn type="button">삭제하기</St.ModalBtn>
+                <St.ModalBtn type="button" onClick={handleDelete}>삭제하기</St.ModalBtn>
             </St.ListModal>
         </St.ListModalWrapper>
     )}

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,13 +1,17 @@
-import { useState } from 'react';
+import { useState } from "react";
 
 const useModal = () => {
   const [isShowing, setIsShowing] = useState(false);
+  const [isDeleteShowing, setIsDeleteShowing] = useState(false);
 
   const toggle = () => setIsShowing((prev) => !prev);
+  const deleteToggle = () => setIsDeleteShowing((prev) => !prev);
 
   return {
     isShowing,
+    isDeleteShowing,
     toggle,
+    deleteToggle
   };
 };
 

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -11,11 +11,11 @@ const ListPage = () => {
   const CATEGORY = ['전체', '월세', '전세', '매매'];
   const FILTER = ['필터', '별점순', '좋아요순'];
   
-  const {isShowing, toggle} = useModal();
+  const {isShowing, toggle, isDeleteShowing, deleteToggle} = useModal();
 
   return (
     <St.ListWrapper>
-      <DeleteModal isDeleteShowing={isShowing} handleToggle={toggle}/>
+      <DeleteModal isDeleteShowing={isDeleteShowing} handleToggle={deleteToggle}/>
       <MoreModal isShowing={isShowing} handleClose={toggle}/>
       <section>
         <St.ListSetting>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -15,7 +15,7 @@ const ListPage = () => {
 
   return (
     <St.ListWrapper>
-      <DeleteModal/>
+      <DeleteModal isDeleteShowing={isShowing} handleToggle={toggle}/>
       <MoreModal isShowing={isShowing} handleClose={toggle}/>
       <section>
         <St.ListSetting>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 import { IcSmallLine } from "../assets/icon/index";
 import AddBox from "../components/List/AddBox";
+import DeleteModal from "../components/List/DeleteModal";
 import MoreModal from "../components/List/MoreModal";
 import ProductBox from "../components/List/ProductBox";
 import useModal from "../hooks/useModal";
@@ -14,6 +15,7 @@ const ListPage = () => {
 
   return (
     <St.ListWrapper>
+      <DeleteModal/>
       <MoreModal isShowing={isShowing} handleClose={toggle}/>
       <section>
         <St.ListSetting>

--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -16,7 +16,7 @@ const ListPage = () => {
   return (
     <St.ListWrapper>
       <DeleteModal isDeleteShowing={isDeleteShowing} handleToggle={deleteToggle}/>
-      <MoreModal isShowing={isShowing} handleClose={toggle}/>
+      <MoreModal isShowing={isShowing} handleClose={toggle} handleDelete={deleteToggle}/>
       <section>
         <St.ListSetting>
           <St.ListCategory>


### PR DESCRIPTION
### 📢 이거 PR 머지할 때 feature-list-modal => develop 도 머지하겠습니다 하고 알려드림!  📢
---
## 🔥 Related Issues

resolved #44 
## 💜 작업 내용
- [x] 삭제 재확인 모달 UI 구현
- [x] 삭제 재확인 모달 뜨는거 커스텀훅으로 구현

## ✅ PR Point
- 이것도 더보기랑 똑같이 무난하게 구현했어용
- useModal 훅 내부에 delete 전용 state랑 handler 하나씩 추가해놨어용
- 더보기 모달에서 삭제하기 버튼 누르면 
  1. 더보기 모달 끔 (toggle)
  2. 삭제 확인 모달 켬 (toggle)
두개 같이 발생하도록 구현했어욤

## 👀 스크린샷 / GIF / 링크

https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/81505421/7824ad43-2105-4dec-822a-d9c4573b765b



