### PR TITLE
[ common/64 ] 헤더 lnb 언더바 위치 조정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -202,7 +202,8 @@ const St = {
     list-style: none;
     position: relative;
 
-    height: 3rem;
+    height: 5.4rem;
+    padding-top: 1.8rem;
 
     & > * {
       ${({ theme }) => theme.fonts.Title5};


### PR DESCRIPTION
## 🔥 Related Issues

resolved #i64

## 💜 작업 내용

- [x] 어느 순간 틀어져 있었던 .. 헤더 lnb 부분 -> 선택된 페이지를 나타내는 하늘색 언더바의 위치를 제자리로 돌려놓았습니다

## ✅ PR Point

- 머지하고 UI가 틀어지진 않았는지 확인하는 습관을 들여야겠어요 ㅎ ㅎ
- 간단한 ui 복구니까 리뷰 코멘트 없이 확인만 함 해주세용

## 😡 Trouble Shooting
x

## 👀 스크린샷 / GIF / 링크
짜잔
<img width="1440" alt="image" src="https://github.com/GO-SOPT-GROUP5/ohouse-client/assets/77691829/1f34da02-b40a-4236-b002-f5360ae28c71">
