### PR TITLE
[ CheckList/27 ] 체크리스트 생성/수정 API 연결

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -20,7 +20,7 @@ const Router = () => {
               <Route path="/help" element={<HelpPage />} />
               <Route path="/list" element={<ListPage />} />
               <Route path="/checklist" element={<CheckListPage />} />
-              <Route path="/checklist/:id" element={<CheckListPage />} />
+              <Route path="/checklist/:checklistId" element={<CheckListPage />} />
             </Route>
             <Route path="*" element={<ErrorPage />} />
           </Routes>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -20,6 +20,7 @@ const Router = () => {
               <Route path="/help" element={<HelpPage />} />
               <Route path="/list" element={<ListPage />} />
               <Route path="/checklist" element={<CheckListPage />} />
+              <Route path="/checklist/:id" element={<CheckListPage />} />
             </Route>
             <Route path="*" element={<ErrorPage />} />
           </Routes>

--- a/src/components/CheckList/Category.tsx
+++ b/src/components/CheckList/Category.tsx
@@ -24,9 +24,6 @@ const Category = () => {
     }
   };
 
-  console.log(selectedSubcategories);
-  console.log(expandedCategories);
-
   const handleClickSubcategory = (e: React.MouseEvent, subcategory: subCategoryInfo) => {
     let copiedSubcategories: number[];
 
@@ -35,8 +32,6 @@ const Category = () => {
       return;
     }
 
-    console.log('클릭');
-    console.log(selectedSubcategories);
     if (selectedSubcategories.includes(subcategory.id)) {
       copiedSubcategories = selectedSubcategories.filter(s => s !== subcategory.id);
     } else {

--- a/src/components/CheckList/Category.tsx
+++ b/src/components/CheckList/Category.tsx
@@ -24,6 +24,8 @@ const Category = () => {
     }
   };
 
+  console.log(selectedSubcategories);
+  console.log(expandedCategories);
   const handleClickSubcategory = (e: React.MouseEvent, subcategory: subCategoryInfo) => {
     let copiedSubcategories: number[];
 
@@ -32,6 +34,8 @@ const Category = () => {
       return;
     }
 
+    console.log('클릭');
+    console.log(selectedSubcategories);
     if (selectedSubcategories.includes(subcategory.id)) {
       copiedSubcategories = selectedSubcategories.filter(s => s !== subcategory.id);
     } else {

--- a/src/components/CheckList/Category.tsx
+++ b/src/components/CheckList/Category.tsx
@@ -37,8 +37,7 @@ const Category = () => {
     } else {
       copiedSubcategories = [...selectedSubcategories, subcategory.id];
     }
-    copiedSubcategories.sort((a, b) => a - b); // Sort the IDs in ascending order
-    setSelectedSubcategories(copiedSubcategories);
+    copiedSubcategories.sort((a, b) => a - b);
 
     e.stopPropagation();
   };

--- a/src/components/CheckList/Category.tsx
+++ b/src/components/CheckList/Category.tsx
@@ -26,6 +26,7 @@ const Category = () => {
 
   console.log(selectedSubcategories);
   console.log(expandedCategories);
+
   const handleClickSubcategory = (e: React.MouseEvent, subcategory: subCategoryInfo) => {
     let copiedSubcategories: number[];
 
@@ -42,6 +43,7 @@ const Category = () => {
       copiedSubcategories = [...selectedSubcategories, subcategory.id];
     }
     copiedSubcategories.sort((a, b) => a - b);
+    setSelectedSubcategories(copiedSubcategories);
 
     e.stopPropagation();
   };

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { ImgEmpty } from '../../assets/image';
 import { CATEGORY_LIST } from '../../constants/category';
-import { selectedSubcategoriesState, showIndexState } from '../../recoil/atom';
-import theme from '../../styles/theme';
+import { editChecklistData } from '../../lib/checklist';
+import { productDataState, selectedSubcategoriesState, showIndexState } from '../../recoil/atom';
 import CheckListItem from './CheckListItem';
 
 const CheckListIndex = () => {
@@ -12,6 +12,8 @@ const CheckListIndex = () => {
     selectedSubcategoriesState,
   );
   const [showIndex] = useRecoilState(showIndexState);
+
+  const [productData, setProductData] = useRecoilState(productDataState);
 
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
@@ -30,6 +32,17 @@ const CheckListIndex = () => {
   );
 
   const handleCompleteEdit = () => {};
+
+  const editChecklist = async (id: number, status: string) => {
+    // id, state 저장된 categoryList 객체 배열 만들기
+
+    try {
+      const result = await editChecklistData(id, status);
+      console.log(result);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   return (
     <St.CheckList>

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -20,6 +20,7 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
   const [showIndex] = useRecoilState(showIndexState);
   const [categoryList, setCategoryList] = useState<categoryListInfo[]>([]);
   const [subCategoryId] = useRecoilState(subCategoryIdState);
+  console.log(categoryList);
 
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
@@ -38,6 +39,7 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
   );
 
   const handleCompleteEdit = () => {
+    console.log('categoryList', categoryList);
     const updatedCategoryList = categoryList.map(category => {
       switch (category.id) {
         case 1:
@@ -70,7 +72,7 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
           return category;
       }
     });
-
+    console.log(updatedCategoryList);
     const editRequest: editCategoryRequest = {
       checkListId: checklistId,
       categoryList: updatedCategoryList,
@@ -86,7 +88,6 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
         checkListId: checkListId,
         categoryList: categoryList,
       });
-      console.log(result);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -11,7 +11,7 @@ import {
   showIndexState,
   subCategoryIdState,
 } from '../../recoil/atom';
-import { categoryListInfo, editCategoryRequest } from '../../types/category';
+import { categoryListInfo, editCategoryRequest, productData } from '../../types/category';
 import CheckListItem from './CheckListItem';
 
 interface CheckListIndexProps {
@@ -44,10 +44,8 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
 
   const handleCompleteEdit = async () => {
     const updatedCategoryList = selectedCategoryOption.categoryList.map(category => {
-      console.log('id:', category.id);
       switch (category.id) {
         case 1:
-          console.log(subCategoryId[0].SUNLIGHT);
           return { ...category, id: subCategoryId[0].SUNLIGHT };
         case 2:
           return { ...category, id: subCategoryId[0].LEAK };
@@ -91,6 +89,7 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
     } catch (error) {
       console.error(error);
     }
+    console.log(selectedCategoryOption);
   };
 
   const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -23,11 +23,10 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
     selectedSubcategoriesState,
   );
   const [showIndex] = useRecoilState(showIndexState);
-  const [categoryList, setCategoryList] = useState<categoryListInfo[]>([]);
   const [subCategoryId] = useRecoilState(subCategoryIdState);
   const [selectedCategoryOption, setSelectedCategoryOption] =
     useRecoilState<editCategoryRequest>(editCategoryState);
-  console.log(subCategoryId);
+
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
       const subcategory = category.subcategories.find(subcategory => subcategory.id === id);
@@ -78,8 +77,6 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
           return category;
       }
     });
-
-    console.log(updatedCategoryList);
 
     const editRequest: editCategoryRequest = {
       checkListId: checklistId,

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -5,22 +5,19 @@ import styled from 'styled-components';
 import { ImgEmpty } from '../../assets/image';
 import { CATEGORY_LIST } from '../../constants/category';
 import { editChecklistData } from '../../lib/checklist';
-import {
-  productDataState,
-  selectedSubcategoriesState,
-  showIndexState,
-  subCategoryIdState,
-} from '../../recoil/atom';
-import { categoryListInfo, editCategoryRequest, subCategoryIdInfo } from '../../types/category';
+import { selectedSubcategoriesState, showIndexState, subCategoryIdState } from '../../recoil/atom';
+import { categoryListInfo, editCategoryRequest } from '../../types/category';
 import CheckListItem from './CheckListItem';
 
-const CheckListIndex = () => {
+interface CheckListIndexProps {
+  checklistId: number;
+}
+
+const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
   const [selectedSubcategories, setSelectedSubcategories] = useRecoilState(
     selectedSubcategoriesState,
   );
   const [showIndex] = useRecoilState(showIndexState);
-
-  const [productData, setProductData] = useRecoilState(productDataState);
   const [categoryList, setCategoryList] = useState<categoryListInfo[]>([]);
   const [subCategoryId] = useRecoilState(subCategoryIdState);
 
@@ -47,14 +44,35 @@ const CheckListIndex = () => {
           return { ...category, id: subCategoryId[0].SUNLIGHT };
         case 2:
           return { ...category, id: subCategoryId[0].LEAK };
-
+        case 5:
+          return { ...category, id: subCategoryId[0].HEATING };
+        case 10:
+          return { ...category, id: subCategoryId[0].SINK_DRAIN };
+        case 11:
+          return { ...category, id: subCategoryId[0].SINK_PRESSURE };
+        case 15:
+          return { ...category, id: subCategoryId[0].WALLPAPER };
+        case 16:
+          return { ...category, id: subCategoryId[0].FLOOR };
+        case 17:
+          return { ...category, id: subCategoryId[0].BALCONY };
+        case 21:
+          return { ...category, id: subCategoryId[0].WASHSTAND_STATUS };
+        case 22:
+          return { ...category, id: subCategoryId[0].WASHSTAND_DRAIN };
+        case 23:
+          return { ...category, id: subCategoryId[0].WASHSTAND_PRESSURE };
+        case 24:
+          return { ...category, id: subCategoryId[0].MOLD };
+        case 25:
+          return { ...category, id: subCategoryId[0].TOILET };
         default:
           return category;
       }
     });
 
     const editRequest: editCategoryRequest = {
-      checkListId: 123,
+      checkListId: checklistId,
       categoryList: updatedCategoryList,
     };
 
@@ -63,7 +81,6 @@ const CheckListIndex = () => {
 
   const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {
     // id, state 저장된 categoryList 객체 배열 만들기
-
     try {
       const result = await editChecklistData({
         checkListId: checkListId,

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
@@ -22,6 +22,7 @@ const CheckListIndex = () => {
 
   const [productData, setProductData] = useRecoilState(productDataState);
   const [categoryList, setCategoryList] = useState<categoryListInfo[]>([]);
+  const [subCategoryId] = useRecoilState(subCategoryIdState);
 
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
@@ -39,7 +40,26 @@ const CheckListIndex = () => {
     subcategory => subcategory >= showIndex[0] && subcategory <= showIndex[1],
   );
 
-  const handleCompleteEdit = () => {};
+  const handleCompleteEdit = () => {
+    const updatedCategoryList = categoryList.map(category => {
+      switch (category.id) {
+        case 1:
+          return { ...category, id: subCategoryId[0].SUNLIGHT };
+        case 2:
+          return { ...category, id: subCategoryId[0].LEAK };
+
+        default:
+          return category;
+      }
+    });
+
+    const editRequest: editCategoryRequest = {
+      checkListId: 123,
+      categoryList: updatedCategoryList,
+    };
+
+    editChecklist(editRequest);
+  };
 
   const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {
     // id, state 저장된 categoryList 객체 배열 만들기

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
@@ -5,6 +6,7 @@ import { ImgEmpty } from '../../assets/image';
 import { CATEGORY_LIST } from '../../constants/category';
 import { editChecklistData } from '../../lib/checklist';
 import { productDataState, selectedSubcategoriesState, showIndexState } from '../../recoil/atom';
+import { categoryListInfo, editCategoryRequest } from '../../types/category';
 import CheckListItem from './CheckListItem';
 
 const CheckListIndex = () => {
@@ -14,6 +16,7 @@ const CheckListIndex = () => {
   const [showIndex] = useRecoilState(showIndexState);
 
   const [productData, setProductData] = useRecoilState(productDataState);
+  const [categoryList, setCategoryList] = useState<categoryListInfo[]>([]);
 
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
@@ -33,11 +36,14 @@ const CheckListIndex = () => {
 
   const handleCompleteEdit = () => {};
 
-  const editChecklist = async (id: number, status: string) => {
+  const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {
     // id, state 저장된 categoryList 객체 배열 만들기
 
     try {
-      const result = await editChecklistData(id, status);
+      const result = await editChecklistData({
+        checkListId: checkListId,
+        categoryList: categoryList,
+      });
       console.log(result);
     } catch (error) {
       console.error(error);

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -64,7 +64,7 @@ const CheckListIndex = () => {
             return (
               <CheckListItem
                 key={id}
-                checklistId={id}
+                categoryId={id}
                 subcategory={subcategory}
                 checklist={checklist}
                 options={options}

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -7,6 +7,7 @@ import { CATEGORY_LIST } from '../../constants/category';
 import { editChecklistData } from '../../lib/checklist';
 import {
   editCategoryState,
+  productDataState,
   selectedSubcategoriesState,
   showIndexState,
   subCategoryIdState,
@@ -23,9 +24,10 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
     selectedSubcategoriesState,
   );
   const [showIndex] = useRecoilState(showIndexState);
-  const [subCategoryId] = useRecoilState(subCategoryIdState);
+  const [subCategoryId, setSubCategoryId] = useRecoilState(subCategoryIdState);
   const [selectedCategoryOption, setSelectedCategoryOption] =
     useRecoilState<editCategoryRequest>(editCategoryState);
+  const [productData, setProductData] = useRecoilState<productData>(productDataState);
 
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
@@ -42,10 +44,14 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
     subcategory => subcategory >= showIndex[0] && subcategory <= showIndex[1],
   );
 
+  console.log('subCategoryId', subCategoryId);
+
   const handleCompleteEdit = async () => {
     const updatedCategoryList = selectedCategoryOption.categoryList.map(category => {
+      console.log(category.id);
       switch (category.id) {
         case 1:
+          console.log(subCategoryId[0].SUNLIGHT);
           return { ...category, id: subCategoryId[0].SUNLIGHT };
         case 2:
           return { ...category, id: subCategoryId[0].LEAK };
@@ -89,11 +95,9 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
     } catch (error) {
       console.error(error);
     }
-    console.log(selectedCategoryOption);
   };
 
   const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {
-    // id, state 저장된 categoryList 객체 배열 만들기
     try {
       const result = await editChecklistData({
         checkListId: checkListId,

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -5,8 +5,13 @@ import styled from 'styled-components';
 import { ImgEmpty } from '../../assets/image';
 import { CATEGORY_LIST } from '../../constants/category';
 import { editChecklistData } from '../../lib/checklist';
-import { productDataState, selectedSubcategoriesState, showIndexState } from '../../recoil/atom';
-import { categoryListInfo, editCategoryRequest } from '../../types/category';
+import {
+  productDataState,
+  selectedSubcategoriesState,
+  showIndexState,
+  subCategoryIdState,
+} from '../../recoil/atom';
+import { categoryListInfo, editCategoryRequest, subCategoryIdInfo } from '../../types/category';
 import CheckListItem from './CheckListItem';
 
 const CheckListIndex = () => {

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
 import { ImgEmpty } from '../../assets/image';
 import { CATEGORY_LIST } from '../../constants/category';
 import { editChecklistData } from '../../lib/checklist';
-import { selectedSubcategoriesState, showIndexState, subCategoryIdState } from '../../recoil/atom';
+import {
+  editCategoryState,
+  selectedSubcategoriesState,
+  showIndexState,
+  subCategoryIdState,
+} from '../../recoil/atom';
 import { categoryListInfo, editCategoryRequest } from '../../types/category';
 import CheckListItem from './CheckListItem';
 
@@ -20,7 +25,8 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
   const [showIndex] = useRecoilState(showIndexState);
   const [categoryList, setCategoryList] = useState<categoryListInfo[]>([]);
   const [subCategoryId] = useRecoilState(subCategoryIdState);
-  console.log(categoryList);
+  const [selectedCategoryOption, setSelectedCategoryOption] =
+    useRecoilState<editCategoryRequest>(editCategoryState);
 
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
@@ -38,9 +44,8 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
     subcategory => subcategory >= showIndex[0] && subcategory <= showIndex[1],
   );
 
-  const handleCompleteEdit = () => {
-    console.log('categoryList', categoryList);
-    const updatedCategoryList = categoryList.map(category => {
+  const handleCompleteEdit = async () => {
+    const updatedCategoryList = selectedCategoryOption.categoryList.map(category => {
       switch (category.id) {
         case 1:
           return { ...category, id: subCategoryId[0].SUNLIGHT };
@@ -72,14 +77,24 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
           return category;
       }
     });
-    console.log(updatedCategoryList);
+
     const editRequest: editCategoryRequest = {
       checkListId: checklistId,
       categoryList: updatedCategoryList,
     };
 
-    editChecklist(editRequest);
+    console.log(editRequest);
+    // editChecklist(editRequest);
+
+    try {
+      const result = await editChecklistData(editRequest);
+      console.log(result);
+    } catch (error) {
+      console.error(error);
+    }
   };
+
+  console.log(selectedCategoryOption);
 
   const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {
     // id, state 저장된 categoryList 객체 배열 만들기
@@ -88,6 +103,7 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
         checkListId: checkListId,
         categoryList: categoryList,
       });
+      console.log(result);
     } catch (error) {
       console.error(error);
     }

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { ImgEmpty } from '../../assets/image';
 import { CATEGORY_LIST } from '../../constants/category';
 import { selectedSubcategoriesState, showIndexState } from '../../recoil/atom';
+import theme from '../../styles/theme';
 import CheckListItem from './CheckListItem';
 
 const CheckListIndex = () => {
@@ -28,29 +29,32 @@ const CheckListIndex = () => {
     subcategory => subcategory >= showIndex[0] && subcategory <= showIndex[1],
   );
 
+  const handleCompleteEdit = () => {};
+
   return (
     <St.CheckList>
       {showSubcategories.length ? (
         showSubcategories.map(id => {
           const { subcategory, checklist, options } = getCategoryInfo(id) || {};
-          return (
-            subcategory &&
-            checklist &&
-            options && (
+          if (subcategory && checklist && options) {
+            return (
               <CheckListItem
                 key={id}
                 subcategory={subcategory}
                 checklist={checklist}
                 options={options}
               />
-            )
-          );
+            );
+          }
         })
       ) : (
         <St.Empty>
           <ImgEmpty />
         </St.Empty>
       )}
+      <St.CompleteEditBtn type="button" onClick={handleCompleteEdit}>
+        수정하기
+      </St.CompleteEditBtn>
     </St.CheckList>
   );
 };
@@ -68,6 +72,16 @@ const St = {
     padding: 3.9rem;
 
     background-color: ${({ theme }) => theme.colors.White};
+  `,
+
+  CompleteEditBtn: styled.button`
+    width: 100%;
+    height: 6.9rem;
+
+    border-radius: 0.4rem;
+    background-color: ${({ theme }) => theme.colors.Blue};
+    color: ${({ theme }) => theme.colors.White};
+    ${({ theme }) => theme.fonts.Title3};
   `,
 
   Empty: styled.div`

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -27,7 +27,7 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
   const [subCategoryId] = useRecoilState(subCategoryIdState);
   const [selectedCategoryOption, setSelectedCategoryOption] =
     useRecoilState<editCategoryRequest>(editCategoryState);
-
+  console.log(subCategoryId);
   const getCategoryInfo = (id: number) => {
     for (const category of CATEGORY_LIST) {
       const subcategory = category.subcategories.find(subcategory => subcategory.id === id);
@@ -36,7 +36,6 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
         return { subcategory: subcategoryName, checklist, options };
       }
     }
-
     return null;
   };
 
@@ -46,8 +45,10 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
 
   const handleCompleteEdit = async () => {
     const updatedCategoryList = selectedCategoryOption.categoryList.map(category => {
+      console.log('id:', category.id);
       switch (category.id) {
         case 1:
+          console.log(subCategoryId[0].SUNLIGHT);
           return { ...category, id: subCategoryId[0].SUNLIGHT };
         case 2:
           return { ...category, id: subCategoryId[0].LEAK };
@@ -78,13 +79,14 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
       }
     });
 
+    console.log(updatedCategoryList);
+
     const editRequest: editCategoryRequest = {
       checkListId: checklistId,
       categoryList: updatedCategoryList,
     };
 
-    console.log(editRequest);
-    // editChecklist(editRequest);
+    editChecklist(editRequest);
 
     try {
       const result = await editChecklistData(editRequest);
@@ -93,8 +95,6 @@ const CheckListIndex = ({ checklistId }: CheckListIndexProps) => {
       console.error(error);
     }
   };
-
-  console.log(selectedCategoryOption);
 
   const editChecklist = async ({ checkListId, categoryList }: editCategoryRequest) => {
     // id, state 저장된 categoryList 객체 배열 만들기

--- a/src/components/CheckList/CheckListIndex.tsx
+++ b/src/components/CheckList/CheckListIndex.tsx
@@ -64,6 +64,7 @@ const CheckListIndex = () => {
             return (
               <CheckListItem
                 key={id}
+                checklistId={id}
                 subcategory={subcategory}
                 checklist={checklist}
                 options={options}

--- a/src/components/CheckList/CheckListItem.tsx
+++ b/src/components/CheckList/CheckListItem.tsx
@@ -1,15 +1,10 @@
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router';
-import { useRecoilState } from 'recoil';
-import styled from 'styled-components';
+import { useEffect, useState } from "react";
+import { useParams } from "react-router";
+import { useRecoilState } from "recoil";
+import styled from "styled-components";
 
-import { editCategoryState, productDataState, subCategoryIdState } from '../../recoil/atom';
-import {
-  categoryListInfo,
-  checkListDataInfo,
-  editCategoryRequest,
-  productData,
-} from '../../types/category';
+import { editCategoryState } from "../../recoil/atom";
+import { editCategoryRequest } from "../../types/category";
 
 interface CheckListItemProms {
   categoryId: number;
@@ -20,11 +15,9 @@ interface CheckListItemProms {
 
 const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckListItemProms) => {
   const { checklistId } = useParams();
-  const [subCategoryId] = useRecoilState(subCategoryIdState);
   const [selectedOptionIndex, setSelectedOptionIndex] = useState<number | null>(null);
   const [selectedCategoryOption, setSelectedCategoryOption] =
     useRecoilState<editCategoryRequest>(editCategoryState);
-  const [productData, setProductData] = useRecoilState<productData>(productDataState);
 
   const handleSelectedOption = (index: number) => {
     if (categoryId && index !== selectedOptionIndex) {

--- a/src/components/CheckList/CheckListItem.tsx
+++ b/src/components/CheckList/CheckListItem.tsx
@@ -45,7 +45,7 @@ const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckLis
   };
 
   useEffect(() => {
-    console.log('selectedCategoryOption', selectedCategoryOption);
+    // console.log('selectedCategoryOption', selectedCategoryOption);
   }, [selectedCategoryOption]);
 
   useEffect(() => {

--- a/src/components/CheckList/CheckListItem.tsx
+++ b/src/components/CheckList/CheckListItem.tsx
@@ -3,8 +3,13 @@ import { useParams } from 'react-router';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
-import { editCategoryState } from '../../recoil/atom';
-import { categoryListInfo, editCategoryRequest } from '../../types/category';
+import { editCategoryState, productDataState, subCategoryIdState } from '../../recoil/atom';
+import {
+  categoryListInfo,
+  checkListDataInfo,
+  editCategoryRequest,
+  productData,
+} from '../../types/category';
 
 interface CheckListItemProms {
   categoryId: number;
@@ -15,9 +20,11 @@ interface CheckListItemProms {
 
 const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckListItemProms) => {
   const { checklistId } = useParams();
+  const [subCategoryId] = useRecoilState(subCategoryIdState);
   const [selectedOptionIndex, setSelectedOptionIndex] = useState<number | null>(null);
   const [selectedCategoryOption, setSelectedCategoryOption] =
     useRecoilState<editCategoryRequest>(editCategoryState);
+  const [productData, setProductData] = useRecoilState<productData>(productDataState);
 
   const handleSelectedOption = (index: number) => {
     if (categoryId && index !== selectedOptionIndex) {
@@ -45,7 +52,7 @@ const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckLis
   };
 
   useEffect(() => {
-    // console.log('selectedCategoryOption', selectedCategoryOption);
+    console.log('selectedCategoryOption', selectedCategoryOption);
   }, [selectedCategoryOption]);
 
   useEffect(() => {

--- a/src/components/CheckList/CheckListItem.tsx
+++ b/src/components/CheckList/CheckListItem.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
-import { useParams } from "react-router";
-import { useRecoilState } from "recoil";
-import styled from "styled-components";
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
 
-import { editCategoryState } from "../../recoil/atom";
-import { editCategoryRequest } from "../../types/category";
+import { editCategoryState } from '../../recoil/atom';
+import { editCategoryRequest } from '../../types/category';
 
 interface CheckListItemProms {
   categoryId: number;
@@ -66,7 +66,12 @@ const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckLis
             key={option}
             onClick={() => handleSelectedOption(index)}
             disabled={index === selectedOptionIndex}
-            active={index === selectedOptionIndex}
+            active={
+              index === selectedOptionIndex ||
+              selectedCategoryOption.categoryList.some(
+                category => category.id === categoryId && category.state === index + 1,
+              )
+            }
           >
             {option}
           </St.OptionBtn>

--- a/src/components/CheckList/CheckListItem.tsx
+++ b/src/components/CheckList/CheckListItem.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import styled from 'styled-components';
 
 interface CheckListItemProms {
+  checklistId: number;
   subcategory: string;
   checklist: string;
   options: string[];
 }
 
-const CheckListItem = ({ subcategory, checklist, options }: CheckListItemProms) => {
+const CheckListItem = ({ checklistId, subcategory, checklist, options }: CheckListItemProms) => {
   const [selectedOption, setSelectedOption] = useState<string>();
 
   const handleSelectedOption = (select: string) => {
@@ -15,6 +16,7 @@ const CheckListItem = ({ subcategory, checklist, options }: CheckListItemProms) 
       setSelectedOption(select);
     }
   };
+  console.log('ddd', checklistId, subcategory, checklist, options);
 
   return (
     <St.CheckListItemWrapper>

--- a/src/components/CheckList/CheckListItem.tsx
+++ b/src/components/CheckList/CheckListItem.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
@@ -13,6 +14,7 @@ interface CheckListItemProms {
 }
 
 const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckListItemProms) => {
+  const { checklistId } = useParams();
   const [selectedOptionIndex, setSelectedOptionIndex] = useState<number | null>(null);
   const [selectedCategoryOption, setSelectedCategoryOption] =
     useRecoilState<editCategoryRequest>(editCategoryState);
@@ -45,6 +47,15 @@ const CheckListItem = ({ categoryId, subcategory, checklist, options }: CheckLis
   useEffect(() => {
     console.log('selectedCategoryOption', selectedCategoryOption);
   }, [selectedCategoryOption]);
+
+  useEffect(() => {
+    if (checklistId) {
+      setSelectedCategoryOption(prevOptions => ({
+        ...prevOptions,
+        checkListId: Number(checklistId),
+      }));
+    }
+  }, [checklistId]);
 
   return (
     <St.CheckListItemWrapper>

--- a/src/components/CheckList/ProductContract.tsx
+++ b/src/components/CheckList/ProductContract.tsx
@@ -218,7 +218,7 @@ const St = {
       right: 1.3rem;
       bottom: 1.1rem;
 
-      color: {({ theme }) => theme.colors.Grey500};
+      color: ${({ theme }) => theme.colors.Grey500};
       ${({ theme }) => theme.fonts.Body5};
     }
   `,

--- a/src/components/CheckList/ProductUpload.tsx
+++ b/src/components/CheckList/ProductUpload.tsx
@@ -1,9 +1,9 @@
-import { useRef, useState } from 'react';
-import styled from 'styled-components';
+import { useRef, useState } from "react";
+import styled from "styled-components";
 
-import { IcCamera, IcEdit, IcStar, IcStarFilled } from '../../assets/icon';
-import useModal from '../../hooks/useModal';
-import ProductEditModal from './ProductEditModal';
+import { IcCamera, IcEdit, IcStar, IcStarFilled } from "../../assets/icon";
+import useModal from "../../hooks/useModal";
+import ProductEditModal from "./ProductEditModal";
 
 const ProductUpload = () => {
   const { isShowing, toggle } = useModal();
@@ -45,12 +45,12 @@ const ProductUpload = () => {
   };
 
   const handleStarClick = (index: number) => {
-    let clickStates = [...starClicked];
-    for (let i = 0; i < 5; i++) {
-      clickStates[i] = i <= index ? true : false;
-    }
-    setStarClicked(clickStates);
-    setGrade(starClicked.filter(Boolean).length); // 서버에게 보낼 별 갯수
+    setStarClicked(prevStarClicked => {
+      const clickStates = prevStarClicked.map((_, i) => i <= index);
+      const updatedGrade = clickStates.filter(Boolean).length;
+      setGrade(updatedGrade);
+      return clickStates;
+    });
   };
 
   const handleCommentChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const client = axios.create({
-  baseURL: import.meta.env.BASE_URL,
+  baseURL: import.meta.env.VITE_BASE_URL,
   headers: {
     'Content-type': 'application/json',
   },

--- a/src/lib/checklist.ts
+++ b/src/lib/checklist.ts
@@ -1,5 +1,5 @@
 import { OHouseResponse } from '../types/axios';
-import { categoryResponse } from '../types/category';
+import { categoryResponse, editCategoryRequest } from '../types/category';
 import { client } from './axios';
 
 // 체크리스트 조회
@@ -13,9 +13,12 @@ export const getChecklistData = async (checklistId: number) => {
 };
 
 // 체크리스트 카테고리 수정
-export const editChecklistData = async (id: number, status: string) => {
+export const editChecklistData = async ({ checkListId, categoryList }: editCategoryRequest) => {
   try {
-    const { data } = await client.patch<OHouseResponse<null>>('/checklist', { id, status });
+    const { data } = await client.patch<OHouseResponse<null>>('/checklist', {
+      checkListId,
+      categoryList,
+    });
     return data.data;
   } catch (err) {
     console.error(err);

--- a/src/lib/checklist.ts
+++ b/src/lib/checklist.ts
@@ -15,11 +15,11 @@ export const getChecklistData = async (checklistId: number) => {
 // 체크리스트 카테고리 수정
 export const editChecklistData = async ({ checkListId, categoryList }: editCategoryRequest) => {
   try {
-    const { data } = await client.patch<OHouseResponse<null>>('/checklist', {
+    const { data } = await client.patch<OHouseResponse<null>>('/category', {
       checkListId,
       categoryList,
     });
-    return data.data;
+    return data;
   } catch (err) {
     console.error(err);
   }

--- a/src/lib/checklist.ts
+++ b/src/lib/checklist.ts
@@ -1,0 +1,23 @@
+import { OHouseResponse } from '../types/axios';
+import { categoryResponse } from '../types/category';
+import { client } from './axios';
+
+// 체크리스트 조회
+export const getChecklistData = async (checklistId: number) => {
+  try {
+    const { data } = await client.get<categoryResponse>(`/checklist/${checklistId}`);
+    return data.data;
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+// 체크리스트 카테고리 수정
+export const editChecklistData = async (id: number, status: string) => {
+  try {
+    const { data } = await client.patch<OHouseResponse<null>>('/checklist', { id, status });
+    return data.data;
+  } catch (err) {
+    console.error(err);
+  }
+};

--- a/src/lib/checklist.ts
+++ b/src/lib/checklist.ts
@@ -1,11 +1,11 @@
 import { OHouseResponse } from '../types/axios';
-import { categoryResponse, editCategoryRequest } from '../types/category';
+import { editCategoryRequest, productData } from '../types/category';
 import { client } from './axios';
 
 // 체크리스트 조회
 export const getChecklistData = async (checklistId: number) => {
   try {
-    const { data } = await client.get<categoryResponse>(`/checklist/${checklistId}`);
+    const { data } = await client.get<OHouseResponse<productData>>(`/checklist/${checklistId}`);
     return data.data;
   } catch (err) {
     console.error(err);

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -12,9 +12,9 @@ export const getProductData = async (productid: number) => {
 };
 
 // 체크리스트 조회
-export const getChecklistData = async (id: number) => {
+export const getChecklistData = async (checklistId: number) => {
   try {
-    const { data } = await client.get<categoryResponse>(`/checklist/${id}`);
+    const { data } = await client.get<categoryResponse>(`/checklist/${checklistId}`);
     return data.data;
   } catch (err) {
     console.error(err);

--- a/src/lib/product.ts
+++ b/src/lib/product.ts
@@ -1,30 +1,8 @@
-import { OHouseResponse } from '../types/axios';
-import { categoryResponse, checkListData } from '../types/category';
 import { client } from './axios';
 
 export const getProductData = async (productid: number) => {
   try {
     const { data } = await client.get(`/${productid}`);
-    return data.data;
-  } catch (err) {
-    console.error(err);
-  }
-};
-
-// 체크리스트 조회
-export const getChecklistData = async (checklistId: number) => {
-  try {
-    const { data } = await client.get<categoryResponse>(`/checklist/${checklistId}`);
-    return data.data;
-  } catch (err) {
-    console.error(err);
-  }
-};
-
-// 체크리스트 카테고리 수정
-export const editChecklistData = async (id: number, status: string) => {
-  try {
-    const { data } = await client.patch<OHouseResponse<null>>('/checklist', { id, status });
     return data.data;
   } catch (err) {
     console.error(err);

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import Category from '../components/CheckList/Category';
 import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
-import { getChecklistData } from '../lib/product';
+import { getChecklistData } from '../lib/checklist';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
@@ -23,6 +23,7 @@ const CheckListPage = () => {
 
   useEffect(() => {
     getChecklist();
+    // getChecklist에서 받아온 데이터 리코일에 저장
   }, [checklistId]);
 
   return (

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -7,18 +7,23 @@ import Category from '../components/CheckList/Category';
 import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 import { getChecklistData } from '../lib/checklist';
-import { subCategoryIdState } from '../recoil/atom';
-import { checkListDataInfo, subCategoryIdInfo } from '../types/category';
+import { productDataState, subCategoryIdState } from '../recoil/atom';
+import { checkListDataInfo, productData, subCategoryIdInfo } from '../types/category';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
   const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
+  const [productData, setProductData] = useRecoilState<productData>(productDataState);
 
   const getChecklist = async () => {
     try {
       if (checklistId) {
         const result = await getChecklistData(Number(checklistId));
+        if (result) {
+          setProductData(result);
+        }
+        console.log(result);
         return result?.checkListData;
       }
     } catch (error) {
@@ -58,6 +63,12 @@ const CheckListPage = () => {
       ]);
     }
   }, [checklist, setSubCategoryId]);
+
+  useEffect(() => {
+    if (checklistId && productData.id !== Number(checklistId)) {
+      getChecklist();
+    }
+  }, [checklistId, productData.id]);
 
   return (
     <St.CheckListPageWrapper>

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -7,13 +7,20 @@ import Category from '../components/CheckList/Category';
 import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 import { getChecklistData } from '../lib/checklist';
-import { subCategoryIdState } from '../recoil/atom';
-import { checkListDataInfo, subCategoryIdInfo } from '../types/category';
+import { editCategoryState, subCategoryIdState } from '../recoil/atom';
+import {
+  categoryListInfo,
+  checkListDataInfo,
+  editCategoryRequest,
+  subCategoryIdInfo,
+} from '../types/category';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
   const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
+  const [selectedCategories, setSelectedCategories] =
+    useRecoilState<editCategoryRequest>(editCategoryState);
 
   const getChecklist = async () => {
     try {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Category from '../components/CheckList/Category';
@@ -5,6 +6,8 @@ import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 
 const CheckListPage = () => {
+  const { id } = useParams();
+
   return (
     <St.CheckListPageWrapper>
       <ProductUpload />

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -8,12 +8,12 @@ import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 import { getChecklistData } from '../lib/checklist';
 import { subCategoryIdState } from '../recoil/atom';
-import { checkListState, subCategoryIdInfo } from '../types/category';
+import { checkListDataInfo, subCategoryIdInfo } from '../types/category';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
-  const [checklist, setChecklist] = useState<checkListState | undefined>(undefined);
+  const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
 
   const getChecklist = async () => {
     try {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -30,9 +30,11 @@ const CheckListPage = () => {
     }
   };
 
-  useEffect(() => {
+  const updateSubCategoryId = () => {
     if (productData.checkListData) {
       const { indoor, kitchen, livingRoom, bathroom } = productData.checkListData;
+
+      console.log(productData.checkListData);
 
       const updatedSubCategoryId = {
         SUNLIGHT: indoor[0].id,
@@ -53,7 +55,13 @@ const CheckListPage = () => {
       setSubCategoryId([updatedSubCategoryId]);
       console.log(subCategoryId);
     }
-  }, [checklistId, setSubCategoryId]);
+  };
+
+  useEffect(() => {
+    if (productData.checkListData) {
+      updateSubCategoryId();
+    }
+  }, [productData.checkListData, setSubCategoryId]);
 
   useEffect(() => {
     if (checklistId && productData.id !== Number(checklistId)) {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -59,8 +59,6 @@ const CheckListPage = () => {
     }
   }, [checklist, setSubCategoryId]);
 
-  console.log(subCategoryId);
-
   return (
     <St.CheckListPageWrapper>
       <ProductUpload />

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -8,12 +8,11 @@ import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 import { getChecklistData } from '../lib/checklist';
 import { productDataState, subCategoryIdState } from '../recoil/atom';
-import { checkListDataInfo, productData, subCategoryIdInfo } from '../types/category';
+import { productData, subCategoryIdInfo } from '../types/category';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
-  // const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
   const [productData, setProductData] = useRecoilState<productData>(productDataState);
 
   const getChecklist = async () => {
@@ -30,15 +29,6 @@ const CheckListPage = () => {
       console.error(error);
     }
   };
-
-  // useEffect(() => {
-  //   const fetchChecklist = async () => {
-  //     const checklistData = await getChecklist();
-  //     setChecklist(checklistData);
-  //   };
-
-  //   fetchChecklist();
-  // }, [checklistId]);
 
   useEffect(() => {
     if (productData.checkListData) {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -44,23 +44,24 @@ const CheckListPage = () => {
     if (productData.checkListData) {
       const { indoor, kitchen, livingRoom, bathroom } = productData.checkListData;
 
-      setSubCategoryId([
-        {
-          SUNLIGHT: indoor[0].id,
-          LEAK: indoor[1].id,
-          HEATING: indoor[2].id,
-          SINK_DRAIN: kitchen[0].id,
-          SINK_PRESSURE: kitchen[1].id,
-          WALLPAPER: livingRoom[0].id,
-          FLOOR: livingRoom[1].id,
-          BALCONY: livingRoom[2].id,
-          WASHSTAND_STATUS: bathroom[0].id,
-          WASHSTAND_DRAIN: bathroom[1].id,
-          WASHSTAND_PRESSURE: bathroom[2].id,
-          MOLD: bathroom[3].id,
-          TOILET: bathroom[4].id,
-        },
-      ]);
+      const updatedSubCategoryId = {
+        SUNLIGHT: indoor[0].id,
+        LEAK: indoor[1].id,
+        HEATING: indoor[2].id,
+        SINK_DRAIN: kitchen[0].id,
+        SINK_PRESSURE: kitchen[1].id,
+        WALLPAPER: livingRoom[0].id,
+        FLOOR: livingRoom[1].id,
+        BALCONY: livingRoom[2].id,
+        WASHSTAND_STATUS: bathroom[0].id,
+        WASHSTAND_DRAIN: bathroom[1].id,
+        WASHSTAND_PRESSURE: bathroom[2].id,
+        MOLD: bathroom[3].id,
+        TOILET: bathroom[4].id,
+      };
+
+      setSubCategoryId([updatedSubCategoryId]);
+      console.log(subCategoryId);
     }
   }, [checklistId, setSubCategoryId]);
 

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -1,20 +1,25 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import Category from '../components/CheckList/Category';
 import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 import { getChecklistData } from '../lib/checklist';
+import { subCategoryIdState } from '../recoil/atom';
+import { checkListState, subCategoryIdInfo } from '../types/category';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
+  const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
+  const [checklist, setChecklist] = useState<checkListState | undefined>(undefined);
 
   const getChecklist = async () => {
     try {
       if (checklistId) {
         const result = await getChecklistData(Number(checklistId));
-        console.log(result);
+        return result?.checkListData;
       }
     } catch (error) {
       console.error(error);
@@ -22,9 +27,39 @@ const CheckListPage = () => {
   };
 
   useEffect(() => {
-    getChecklist();
-    // getChecklist에서 받아온 데이터 리코일에 저장
+    const fetchChecklist = async () => {
+      const checklistData = await getChecklist();
+      setChecklist(checklistData);
+    };
+
+    fetchChecklist();
   }, [checklistId]);
+
+  useEffect(() => {
+    if (checklist) {
+      const { indoor, kitchen, livingRoom, bathroom } = checklist;
+
+      setSubCategoryId([
+        {
+          SUNLIGHT: indoor[0].id,
+          LEAK: indoor[1].id,
+          HEATING: indoor[2].id,
+          SINK_DRAIN: kitchen[0].id,
+          SINK_PRESSURE: kitchen[1].id,
+          WALLPAPER: livingRoom[0].id,
+          FLOOR: livingRoom[1].id,
+          BALCONY: livingRoom[2].id,
+          WASHSTAND_STATUS: bathroom[0].id,
+          WASHSTAND_DRAIN: bathroom[1].id,
+          WASHSTAND_PRESSURE: bathroom[2].id,
+          MOLD: bathroom[3].id,
+          TOILET: bathroom[4].id,
+        },
+      ]);
+    }
+  }, [checklist, setSubCategoryId]);
+
+  console.log(subCategoryId);
 
   return (
     <St.CheckListPageWrapper>

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -66,7 +66,7 @@ const CheckListPage = () => {
       <ProductUpload />
       <St.CheckListWarpper>
         <Category />
-        <CheckListIndex />
+        <CheckListIndex checklistId={Number(checklistId)} />
       </St.CheckListWarpper>
     </St.CheckListPageWrapper>
   );

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -19,8 +19,8 @@ const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
   const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
-  const [selectedCategories, setSelectedCategories] =
-    useRecoilState<editCategoryRequest>(editCategoryState);
+  // const [selectedCategories, setSelectedCategories] =
+  //   useRecoilState<editCategoryRequest>(editCategoryState);
 
   const getChecklist = async () => {
     try {
@@ -35,10 +35,10 @@ const CheckListPage = () => {
 
   useEffect(() => {
     if (checklistId) {
-      setSelectedCategories(prevState => ({
-        ...prevState,
-        checkListId: Number(checklistId),
-      }));
+      // setSelectedCategories(prevState => ({
+      //   ...prevState,
+      //   checkListId: Number(checklistId),
+      // }));
     }
 
     const fetchChecklist = async () => {
@@ -49,7 +49,7 @@ const CheckListPage = () => {
     fetchChecklist();
   }, [checklistId]);
 
-  console.log(selectedCategories);
+  // console.log(selectedCategories);
 
   useEffect(() => {
     if (checklist) {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -34,6 +34,13 @@ const CheckListPage = () => {
   };
 
   useEffect(() => {
+    if (checklistId) {
+      setSelectedCategories(prevState => ({
+        ...prevState,
+        checkListId: Number(checklistId),
+      }));
+    }
+
     const fetchChecklist = async () => {
       const checklistData = await getChecklist();
       setChecklist(checklistData);
@@ -41,6 +48,8 @@ const CheckListPage = () => {
 
     fetchChecklist();
   }, [checklistId]);
+
+  console.log(selectedCategories);
 
   useEffect(() => {
     if (checklist) {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -13,7 +13,7 @@ import { checkListDataInfo, productData, subCategoryIdInfo } from '../types/cate
 const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
-  const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
+  // const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
   const [productData, setProductData] = useRecoilState<productData>(productDataState);
 
   const getChecklist = async () => {
@@ -31,18 +31,18 @@ const CheckListPage = () => {
     }
   };
 
-  useEffect(() => {
-    const fetchChecklist = async () => {
-      const checklistData = await getChecklist();
-      setChecklist(checklistData);
-    };
+  // useEffect(() => {
+  //   const fetchChecklist = async () => {
+  //     const checklistData = await getChecklist();
+  //     setChecklist(checklistData);
+  //   };
 
-    fetchChecklist();
-  }, [checklistId]);
+  //   fetchChecklist();
+  // }, [checklistId]);
 
   useEffect(() => {
-    if (checklist) {
-      const { indoor, kitchen, livingRoom, bathroom } = checklist;
+    if (productData.checkListData) {
+      const { indoor, kitchen, livingRoom, bathroom } = productData.checkListData;
 
       setSubCategoryId([
         {
@@ -62,7 +62,7 @@ const CheckListPage = () => {
         },
       ]);
     }
-  }, [checklist, setSubCategoryId]);
+  }, [checklistId, setSubCategoryId]);
 
   useEffect(() => {
     if (checklistId && productData.id !== Number(checklistId)) {

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -1,12 +1,29 @@
+import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Category from '../components/CheckList/Category';
 import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
+import { getChecklistData } from '../lib/product';
 
 const CheckListPage = () => {
-  const { id } = useParams();
+  const { checklistId } = useParams();
+
+  const getChecklist = async () => {
+    try {
+      if (checklistId) {
+        const result = await getChecklistData(Number(checklistId));
+        console.log(result);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getChecklist();
+  }, [checklistId]);
 
   return (
     <St.CheckListPageWrapper>

--- a/src/pages/CheckListPage.tsx
+++ b/src/pages/CheckListPage.tsx
@@ -7,20 +7,13 @@ import Category from '../components/CheckList/Category';
 import CheckListIndex from '../components/CheckList/CheckListIndex';
 import ProductUpload from '../components/CheckList/ProductUpload';
 import { getChecklistData } from '../lib/checklist';
-import { editCategoryState, subCategoryIdState } from '../recoil/atom';
-import {
-  categoryListInfo,
-  checkListDataInfo,
-  editCategoryRequest,
-  subCategoryIdInfo,
-} from '../types/category';
+import { subCategoryIdState } from '../recoil/atom';
+import { checkListDataInfo, subCategoryIdInfo } from '../types/category';
 
 const CheckListPage = () => {
   const { checklistId } = useParams();
   const [subCategoryId, setSubCategoryId] = useRecoilState<subCategoryIdInfo[]>(subCategoryIdState);
   const [checklist, setChecklist] = useState<checkListDataInfo | undefined>(undefined);
-  // const [selectedCategories, setSelectedCategories] =
-  //   useRecoilState<editCategoryRequest>(editCategoryState);
 
   const getChecklist = async () => {
     try {
@@ -34,13 +27,6 @@ const CheckListPage = () => {
   };
 
   useEffect(() => {
-    if (checklistId) {
-      // setSelectedCategories(prevState => ({
-      //   ...prevState,
-      //   checkListId: Number(checklistId),
-      // }));
-    }
-
     const fetchChecklist = async () => {
       const checklistData = await getChecklist();
       setChecklist(checklistData);
@@ -48,8 +34,6 @@ const CheckListPage = () => {
 
     fetchChecklist();
   }, [checklistId]);
-
-  // console.log(selectedCategories);
 
   useEffect(() => {
     if (checklist) {
@@ -110,3 +94,6 @@ const St = {
     margin-top: 1.5rem;
   `,
 };
+function setEditCategory(arg0: (prevEditCategory: any) => any) {
+  throw new Error('Function not implemented.');
+}

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -23,8 +23,83 @@ export const productDataState = atom<productData>({
       size: 0,
     },
     grade: 0,
+    checkListData: {
+      indoor: [
+        {
+          id: 0,
+          subCategoryStatus: 'SUNLIGHT',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'LEAK',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'HEATING',
+          state: 0,
+        },
+      ],
+      kitchen: [
+        {
+          id: 0,
+          subCategoryStatus: 'SINK_DRAIN',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'SINK_PRESSURE',
+          state: 0,
+        },
+      ],
+      livingRoom: [
+        {
+          id: 0,
+          subCategoryStatus: 'WALLPAPER',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'FLOOR',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'BALCONY',
+          state: 0,
+        },
+      ],
+      bathroom: [
+        {
+          id: 0,
+          subCategoryStatus: 'WASHSTAND_STATUS',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'WASHSTAND_DRAIN',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'WASHSTAND_PRESSURE',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'MOLD',
+          state: 0,
+        },
+        {
+          id: 0,
+          subCategoryStatus: 'TOILET',
+          state: 0,
+        },
+      ],
+    },
   },
-  effects_UNSTABLE: [persistAtom],
+  // effects_UNSTABLE: [persistAtom],
 });
 
 export const selectedSubcategoriesState = atom<number[]>({

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,7 +1,12 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
-import { editCategoryRequest, productData, subCategoryIdInfo } from '../types/category';
+import {
+  categoryIdList,
+  editCategoryRequest,
+  productData,
+  subCategoryIdInfo,
+} from '../types/category';
 
 //페이지가 변경되더라도 상태관리를 유지
 const { persistAtom } = recoilPersist();
@@ -112,23 +117,73 @@ export const showIndexState = atom<number[]>({
   default: [1, 48],
 });
 
-export const clientSubCategoryIdState = atom<subCategoryIdInfo[]>({
+export const clientSubCategoryIdState = atom<categoryIdList[]>({
   key: 'clientSubCategoryId',
   default: [
     {
-      SUNLIGHT: 1,
-      LEAK: 2,
-      HEATING: 5,
-      SINK_DRAIN: 10,
-      SINK_PRESSURE: 11,
-      WALLPAPER: 15,
-      FLOOR: 16,
-      BALCONY: 17,
-      WASHSTAND_STATUS: 21,
-      WASHSTAND_DRAIN: 22,
-      WASHSTAND_PRESSURE: 23,
-      MOLD: 24,
-      TOILET: 25,
+      id: 1,
+      name: 'SUNLIGHT',
+      fetchedId: 0,
+    },
+    {
+      id: 2,
+      name: 'LEAK',
+      fetchedId: 0,
+    },
+    {
+      id: 5,
+      name: 'HEATING',
+      fetchedId: 0,
+    },
+    {
+      id: 10,
+      name: 'SINK_DRAIN',
+      fetchedId: 0,
+    },
+    {
+      id: 11,
+      name: 'SINK_PRESSURE',
+      fetchedId: 0,
+    },
+    {
+      id: 15,
+      name: 'WALLPAPER',
+      fetchedId: 0,
+    },
+    {
+      id: 16,
+      name: 'FLOOR',
+      fetchedId: 0,
+    },
+    {
+      id: 17,
+      name: 'BALCONY',
+      fetchedId: 0,
+    },
+    {
+      id: 21,
+      name: 'WASHSTAND_STATUS',
+      fetchedId: 0,
+    },
+    {
+      id: 22,
+      name: 'WASHSTAND_DRAIN',
+      fetchedId: 0,
+    },
+    {
+      id: 23,
+      name: 'WASHSTAND_PRESSURE',
+      fetchedId: 0,
+    },
+    {
+      id: 24,
+      name: 'MOLD',
+      fetchedId: 0,
+    },
+    {
+      id: 25,
+      name: 'TOILET',
+      fetchedId: 0,
     },
   ],
 });

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,8 +1,8 @@
-import { atom } from "recoil";
-import { recoilPersist } from "recoil-persist";
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
 
-import { productData, SubCategoryIdInfo } from "../types/category";
-import { productInfo } from "../types/product";
+import { productData, subCategoryIdInfo } from '../types/category';
+import { productInfo } from '../types/product';
 
 //페이지가 변경되더라도 상태관리를 유지
 const { persistAtom } = recoilPersist();
@@ -38,8 +38,8 @@ export const showIndexState = atom<number[]>({
   default: [1, 48],
 });
 
-export const SubCategoryIdState = atom<SubCategoryIdInfo[]>({
-  key: 'SubCategoryId',
+export const subCategoryIdState = atom<subCategoryIdInfo[]>({
+  key: 'subCategoryId',
   default: [
     {
       SUNLIGHT: 1,

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,8 +1,8 @@
-import { atom } from 'recoil';
-import { recoilPersist } from 'recoil-persist';
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
 
-import { productData } from '../types/category';
-import { productInfo } from '../types/product';
+import { productData, SubCategoryIdInfo } from "../types/category";
+import { productInfo } from "../types/product";
 
 //페이지가 변경되더라도 상태관리를 유지
 const { persistAtom } = recoilPersist();
@@ -36,4 +36,25 @@ export const selectedSubcategoriesState = atom<number[]>({
 export const showIndexState = atom<number[]>({
   key: 'showIndex',
   default: [1, 48],
+});
+
+export const SubCategoryIdState = atom<SubCategoryIdInfo[]>({
+  key: 'SubCategoryId',
+  default: [
+    {
+      SUNLIGHT: 1,
+      LEAK: 2,
+      HEATING: 5,
+      SINK_DRAIN: 10,
+      SINK_PRESSURE: 11,
+      WALLPAPER: 15,
+      FLOOR: 16,
+      BALCONY: 17,
+      WASHSTAND_STATUS: 21,
+      WASHSTAND_DRAIN: 22,
+      WASHSTAND_PRESSURE: 23,
+      MOLD: 24,
+      TOILET: 25,
+    },
+  ],
 });

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -112,6 +112,27 @@ export const showIndexState = atom<number[]>({
   default: [1, 48],
 });
 
+export const clientSubCategoryIdState = atom<subCategoryIdInfo[]>({
+  key: 'clientSubCategoryId',
+  default: [
+    {
+      SUNLIGHT: 1,
+      LEAK: 2,
+      HEATING: 5,
+      SINK_DRAIN: 10,
+      SINK_PRESSURE: 11,
+      WALLPAPER: 15,
+      FLOOR: 16,
+      BALCONY: 17,
+      WASHSTAND_STATUS: 21,
+      WASHSTAND_DRAIN: 22,
+      WASHSTAND_PRESSURE: 23,
+      MOLD: 24,
+      TOILET: 25,
+    },
+  ],
+});
+
 export const subCategoryIdState = atom<subCategoryIdInfo[]>({
   key: 'subCategoryId',
   default: [

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,8 +1,7 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
-import { productData, subCategoryIdInfo } from '../types/category';
-import { productInfo } from '../types/product';
+import { editCategoryRequest, productData, subCategoryIdInfo } from '../types/category';
 
 //페이지가 변경되더라도 상태관리를 유지
 const { persistAtom } = recoilPersist();
@@ -57,4 +56,17 @@ export const subCategoryIdState = atom<subCategoryIdInfo[]>({
       TOILET: 25,
     },
   ],
+});
+
+export const editCategoryState = atom<editCategoryRequest>({
+  key: 'editCategoryInfo',
+  default: {
+    checkListId: 0,
+    categoryList: [
+      {
+        id: 0,
+        state: 1,
+      },
+    ],
+  },
 });

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -62,11 +62,6 @@ export const editCategoryState = atom<editCategoryRequest>({
   key: 'editCategoryInfo',
   default: {
     checkListId: 0,
-    categoryList: [
-      {
-        id: 0,
-        state: 1,
-      },
-    ],
+    categoryList: [],
   },
 });

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,18 +1,21 @@
 import { atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
+import { productData } from '../types/category';
 import { productInfo } from '../types/product';
 
 //페이지가 변경되더라도 상태관리를 유지
 const { persistAtom } = recoilPersist();
 
 // unique ID 를 가지고 초기 값을 지정해주어야 합니다! (예시)
-export const productInfoState = atom<productInfo>({
+export const productDataState = atom<productData>({
   key: 'productInfo',
   default: {
-    id: '',
+    id: 0,
     title: '',
-    createAt: new Date(),
+    address: '',
+    dong: 0,
+    ho: 0,
     image: '',
     description: '',
     tags: {

--- a/src/types/axios.ts
+++ b/src/types/axios.ts
@@ -1,6 +1,5 @@
 export interface OHouseResponse<T> {
-  data?: T;
-  status: number;
-  success: boolean;
+  code: number;
   message: string;
+  data: T;
 }

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -77,3 +77,19 @@ export interface categoryListInfo {
   id: number;
   state: number;
 }
+
+export interface SubCategoryIdInfo {
+  SUNLIGHT: number;
+  LEAK: number;
+  HEATING: number;
+  SINK_DRAIN: number;
+  SINK_PRESSURE: number;
+  WALLPAPER: number;
+  FLOOR: number;
+  BALCONY: number;
+  WASHSTAND_STATUS: number;
+  WASHSTAND_DRAIN: number;
+  WASHSTAND_PRESSURE: number;
+  MOLD: number;
+  TOILET: number;
+}

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -117,3 +117,9 @@ export interface subCategoryIdInfo {
   MOLD: number;
   TOILET: number;
 }
+
+export interface categoryIdList {
+  id: number;
+  name: string;
+  fetchedId: number;
+}

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -22,6 +22,7 @@ export interface productData {
   description: string;
   grade: number;
   tags: tagObject;
+  checkListData: checkListDataInfo;
 }
 
 // 매물 정보 태그 내용 object
@@ -31,23 +32,17 @@ export interface tagObject {
   size: number;
 }
 
-export interface categoryResponse {
-  code: number;
-  message: string;
-  data: checkListData;
-}
-
-export interface checkListData {
-  id: number;
-  title: string;
-  address: string;
-  dong: number;
-  ho: number;
-  image: string;
-  grade: number;
-  tag: tagObject;
-  checkListData: checkListDataInfo;
-}
+// export interface checkListData {
+//   id: number;
+//   title: string;
+//   address: string;
+//   dong: number;
+//   ho: number;
+//   image: string;
+//   grade: number;
+//   tag: tagObject;
+//   checkListData: checkListDataInfo;
+// }
 
 // export interface subCategoryData {
 //   id: number;
@@ -90,10 +85,11 @@ export interface checkListDataInfo {
   livingRoom: subCheckListInfo[];
   bathroom: subCheckListInfo[];
 }
+
 export interface subCheckListInfo {
   id: number;
-  name: string;
-  status: number;
+  subCategoryStatus: string;
+  state: number;
 }
 
 export interface editCategoryRequest {

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -78,7 +78,7 @@ export interface categoryListInfo {
   state: number;
 }
 
-export interface SubCategoryIdInfo {
+export interface subCategoryIdInfo {
   SUNLIGHT: number;
   LEAK: number;
   HEATING: number;

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -11,6 +11,26 @@ export interface subCategoryInfo {
   isDisable: boolean;
 }
 
+//매물 정보 수정 API type
+export interface productData {
+  id: number;
+  title: string;
+  address: string;
+  dong: number;
+  ho: number;
+  image: string;
+  description: string;
+  grade: number;
+  tags: tagObject;
+}
+
+// 매물 정보 태그 내용 object
+export interface tagObject {
+  state: string;
+  price: string;
+  size: number;
+}
+
 export interface categoryResponse {
   code: number;
   message: string;

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -67,3 +67,13 @@ export interface checkListState {
   livingRoom: subCategoryData[];
   bathroom: subCategoryData[];
 }
+
+export interface editCategoryRequest {
+  checkListId: number;
+  categoryList: categoryListInfo[];
+}
+
+export interface categoryListInfo {
+  id: number;
+  state: number;
+}

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -45,35 +45,22 @@ export interface checkListData {
   ho: number;
   image: string;
   grade: number;
-  tag: tagInfo;
-  checkListData: checkListState;
+  tag: tagObject;
+  checkListData: checkListDataInfo;
 }
 
-export interface subCategoryData {
-  id: number;
-  subCategoryStatus: string;
-  state: number;
-}
+// export interface subCategoryData {
+//   id: number;
+//   subCategoryStatus: string;
+//   state: number;
+// }
 
-export interface tagInfo {
-  price: string;
-  size: number;
-  state: string;
-}
+// export interface tagInfo {
+//   price: string;
+//   size: number;
+//   state: string;
+// }
 
-//매물 정보 수정 API type
-export interface productData {
-  id: number;
-  title: string;
-  address: string;
-  dong: number;
-  ho: number;
-  createAt: string;
-  image: string;
-  description: string;
-  grade: number;
-  tags: tagObject;
-}
 // 매물 정보 태그 내용 object
 export interface tagObject {
   state: string;
@@ -100,10 +87,11 @@ export interface checkListData {
 export interface checkListDataInfo {
   indoor: subCheckListInfo[];
   kitchen: subCheckListInfo[];
-  livingroom: subCheckListInfo[];
+  livingRoom: subCheckListInfo[];
   bathroom: subCheckListInfo[];
 }
 export interface subCheckListInfo {
+  id: number;
   name: string;
   status: number;
 }


### PR DESCRIPTION
## 🔥 Related Issues

resolved #27 

## 💜 작업 내용

- 체크리스트 생성/수정 API 연결했습니다!

## ✅ PR Point

- ### lib/category.ts
> 체크리스트 조회, 카테고리 수정 API 연결 함수 작성했습니다!

- ### recoil/atom.ts
> 체크리스트 조회, 카테고리 수정 기능에 필요한 전역 상태입니다!

- **productDataState**
    - 매물 등록 시 받아온 checklistId를 이용해서 해당 매물의 체크리스트를 수정하기 위한 전역상태입니다!

- **clientSubCategoryIdState**
    - 클라이언트에서 카테고리를 순서대로 정렬하기 위해 부여한 category id값과 서버에서 보내는 각 카테고리의 id 값이 달라서, 서버에서 받아온 id값을 저장하기 위한 상태입니다!
 
- **subCategoryIdState**
    - 클라이언트에서 실제로 사용하는 카테고리 id만 저장하기 위한 상태입니다!
 
- **editCategoryState**
    - 수정할 카테고리들을 저장해두고 한 번에 요청을 보내기 위해 만든 전역상태입니다!


## 😡 Trouble Shooting

## 👀 스크린샷 / GIF / 링크

## 📚 Reference

- 구현에 참고한 링크 (필요한 경우만 작성하고 없으면 지우기)
